### PR TITLE
SendToPile -> TrySendToPile

### DIFF
--- a/Library/DeckbuilderLibrary/Content/Cards/Attack10DamageExhaust.cs
+++ b/Library/DeckbuilderLibrary/Content/Cards/Attack10DamageExhaust.cs
@@ -36,7 +36,7 @@ namespace Content.Cards
         {
             if (args.CardId == Id)
             {
-                Context.SendToPile(Id, PileType.ExhaustPile);
+                Context.TrySendToPile(Id, PileType.ExhaustPile);
             }
         }
     }

--- a/Library/DeckbuilderLibrary/Content/Cards/Attack5Damage.cs
+++ b/Library/DeckbuilderLibrary/Content/Cards/Attack5Damage.cs
@@ -17,7 +17,7 @@ namespace Content.Cards
         {
             if (args.CardId == Id)
             {
-                Context.SendToPile(Id, PileType.DiscardPile);
+                Context.TrySendToPile(Id, PileType.DiscardPile);
             }
         }
 

--- a/Library/DeckbuilderLibrary/Content/Cards/DealMoreDamageEachPlay.cs
+++ b/Library/DeckbuilderLibrary/Content/Cards/DealMoreDamageEachPlay.cs
@@ -44,7 +44,7 @@ namespace Content.Cards
         {
             if (args.CardId == Id)
             {
-                Context.SendToPile(Id, PileType.DiscardPile);
+                Context.TrySendToPile(Id, PileType.DiscardPile);
             }
         }
     }

--- a/Library/DeckbuilderLibrary/Content/Cards/DoubleNextCardDamage.cs
+++ b/Library/DeckbuilderLibrary/Content/Cards/DoubleNextCardDamage.cs
@@ -47,7 +47,7 @@ namespace Content.Cards
         {
             if (args.CardId == Id)
             {
-                Context.SendToPile(Id, PileType.ExhaustPile);
+                Context.TrySendToPile(Id, PileType.ExhaustPile);
             }
             else if (Activated)
             {

--- a/Library/DeckbuilderLibrary/DeckbuilderLibrary/Data/GameContext.cs
+++ b/Library/DeckbuilderLibrary/DeckbuilderLibrary/Data/GameContext.cs
@@ -47,27 +47,27 @@ public class GameContext : ITestContext
 
     private void SendToDiscard(int cardId)
     {
-        SendToPile(cardId, PileType.DiscardPile);
+        TrySendToPile(cardId, PileType.DiscardPile);
     }
 
 
     private void SendToExhaust(int cardId)
     {
-        SendToPile(cardId, PileType.ExhaustPile);
+        TrySendToPile(cardId, PileType.ExhaustPile);
     }
 
     private void SendToDraw(int cardId)
     {
-        SendToPile(cardId, PileType.DrawPile);
+        TrySendToPile(cardId, PileType.DrawPile);
     }
 
     private void SendToHand(int cardId)
     {
-        SendToPile(cardId, PileType.HandPile);
+        TrySendToPile(cardId, PileType.HandPile);
     }
 
 
-    public void SendToPile(int cardId, PileType pileType)
+    public void TrySendToPile(int cardId, PileType pileType)
     {
         if (!EntitiesById.TryGetValue(cardId, out IGameEntity entity))
         {

--- a/Library/DeckbuilderLibrary/DeckbuilderLibrary/Data/IContext.cs
+++ b/Library/DeckbuilderLibrary/DeckbuilderLibrary/Data/IContext.cs
@@ -13,7 +13,7 @@ public interface IContext
     IGameEventHandler Events { get; }
     void AddEntity(IGameEntity entity);
 
-    void SendToPile(int cardId, PileType pileType);
+    void TrySendToPile(int cardId, PileType pileType);
     T CreateEntity<T>() where T : GameEntity, new();
     IDeck CreateDeck();
     IPile CreatePile();


### PR DESCRIPTION
Cards like [Corruption](https://static.wikia.nocookie.net/slay-the-spire/images/7/75/Corruption.png/revision/latest/scale-to-width-down/350?cb=20200128065608) change how Piles work. `SendToPile` should become `TrySendToPile`, just as `DealDamage` became `TryDealDamage`.

Ideally, Cards should not have access to **any** method that can change gamestate. This can be achieved in 2 ways:
## Solutions
### Change ALL "Set" methods on `Context` to "Try" methods
There are some weird ones there though; for example, `CreateBattle` -> `TryCreateBattle`. Should cards even have the ability to create a battle?
### Have a separate API for scripting
We had something similar to this last week.