### PR TITLE
#19

### DIFF
--- a/App/Assets/Scenes/BattleScene.unity
+++ b/App/Assets/Scenes/BattleScene.unity
@@ -889,7 +889,7 @@ MonoBehaviour:
   m_BattleProxy: {fileID: 1690915855}
   m_PlayerProxy: {fileID: 1391915691}
   m_EnemyActorManager: {fileID: 1988359170}
-  m_NumCardsInTestDeck: 15
+  m_NumCardsInTestDeck: 6
   m_EndTurnButton: {fileID: 2083889976}
 --- !u!1 &2083889973
 GameObject:
@@ -1643,6 +1643,22 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1692789472}
     m_Modifications:
+    - target: {fileID: 1866567490, guid: e4695863c1b579f4b8a3601426db0ba7, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1866567490, guid: e4695863c1b579f4b8a3601426db0ba7, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1866567490, guid: e4695863c1b579f4b8a3601426db0ba7, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1866567490, guid: e4695863c1b579f4b8a3601426db0ba7, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7708141058731495316, guid: e4695863c1b579f4b8a3601426db0ba7,
         type: 3}
       propertyPath: m_Pivot.x
@@ -1752,6 +1768,26 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Player Proxy
+      objectReference: {fileID: 0}
+    - target: {fileID: 7708141060277917348, guid: e4695863c1b579f4b8a3601426db0ba7,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7708141060277917348, guid: e4695863c1b579f4b8a3601426db0ba7,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7708141060277917348, guid: e4695863c1b579f4b8a3601426db0ba7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7708141060277917348, guid: e4695863c1b579f4b8a3601426db0ba7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e4695863c1b579f4b8a3601426db0ba7, type: 3}

--- a/App/Assets/Scripts/BattleBootstrap.cs
+++ b/App/Assets/Scripts/BattleBootstrap.cs
@@ -46,7 +46,7 @@ public class BattleBootstrap : MonoBehaviour
 
         EndTurnButton.onClick.AddListener(EndTurn);
         PlayerActor player = Api.CreateActor<PlayerActor>(100, 0);
-        Actor enemy = Api.CreateActor<BasicEnemy>(100, 0);
+        Enemy enemy = Api.CreateActor<BasicEnemy>(100, 0);
         IDeck deck = Api.CreateDeck();
 
 
@@ -64,9 +64,7 @@ public class BattleBootstrap : MonoBehaviour
             deck.DrawPile.Cards.Add(Api.CreateEntity<DoubleNextCardDamage>());
         }
 
-        IBattle battle = Api.CreateBattle(deck, player);
-        battle.AddEnemy(enemy);
-        Api.SetCurrentBattle(battle);
+        IBattle battle = Api.CreateBattle(deck, player, new List<Enemy>{enemy});
         InitializeProxies(battle);
     }
 

--- a/Library/DeckbuilderLibrary/DeckbuilderLibrary/Data/GameContext.cs
+++ b/Library/DeckbuilderLibrary/DeckbuilderLibrary/Data/GameContext.cs
@@ -5,6 +5,7 @@ using System.Runtime.Serialization;
 using DeckbuilderLibrary.Data.GameEntities;
 using DeckbuilderLibrary.Data.GameEntities.Actors;
 using DeckbuilderLibrary.Data.GameEntities.Resources;
+using DeckbuilderLibrary.Data.GameEntities.Rules;
 using JsonNet.ContractResolvers;
 using Newtonsoft.Json;
 
@@ -217,13 +218,19 @@ namespace DeckbuilderLibrary.Data
             return actor;
         }
 
-        public IBattle CreateBattle(IDeck deck, PlayerActor player)
+        public IBattle CreateBattle(IDeck deck, PlayerActor player, List<Enemy> enemies)
         {
             var battle = CreateEntity<Battle>();
+            CurrentBattle = battle;
             battle.SetDeck(deck);
             battle.SetPlayer(player);
+            foreach (var enemy in enemies)
+            {
+                battle.AddEnemy(enemy);//might need set access instead.
+            }
 
+            battle.Rules.Add(CreateEntity<ShuffleDiscardIntoDrawWhenEmpty>());
             return battle;
         }
     }
-    }
+}

--- a/Library/DeckbuilderLibrary/DeckbuilderLibrary/Data/GameEntities/Battle.cs
+++ b/Library/DeckbuilderLibrary/DeckbuilderLibrary/Data/GameEntities/Battle.cs
@@ -13,7 +13,8 @@ namespace DeckbuilderLibrary.Data.GameEntities
         [JsonProperty] public PlayerActor Player { get; private set; }
         [JsonProperty] public List<Actor> Enemies { get; private set; }
         [JsonProperty] public IDeck Deck { get; private set; }
-        
+        [JsonProperty] public List<GameEntity> Rules { get; private set; } = new List<GameEntity>();
+
 
         protected override void Initialize()
         {
@@ -66,6 +67,5 @@ namespace DeckbuilderLibrary.Data.GameEntities
 
             Deck = deck;
         }
-
     }
 }

--- a/Library/DeckbuilderLibrary/DeckbuilderLibrary/Data/GameEntities/Rules/ShuffleDiscardIntoDrawWhenEmpty.cs
+++ b/Library/DeckbuilderLibrary/DeckbuilderLibrary/Data/GameEntities/Rules/ShuffleDiscardIntoDrawWhenEmpty.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using DeckbuilderLibrary.Data.Events;
+
+namespace DeckbuilderLibrary.Data.GameEntities.Rules
+{
+    public class ShuffleDiscardIntoDrawWhenEmpty : GameEntity
+    {
+        private IDeck Deck { get; set; }
+        protected override void Initialize()
+        {
+            base.Initialize();
+            Deck = Context.GetCurrentBattle().Deck;
+            //In most games, this actually is checked when the player tries to draw a card. Will have to change this.
+            Context.Events.CardMoved += OnCardMoved;
+        }
+
+        private void OnCardMoved(object sender, CardMovedEventArgs args)
+        {
+            if (Deck.DrawPile.Cards.Count == 0)
+            {
+                Context.Events.CardMoved -= OnCardMoved;
+                foreach (Card discardPileCard in Deck.DiscardPile.Cards.ToList())
+                {
+                    Deck.TrySendToPile(discardPileCard, PileType.DrawPile);
+                }
+                Context.Events.CardMoved += OnCardMoved;
+            }
+        }
+    }
+}

--- a/Library/DeckbuilderLibrary/DeckbuilderLibrary/Data/IContext.cs
+++ b/Library/DeckbuilderLibrary/DeckbuilderLibrary/Data/IContext.cs
@@ -7,7 +7,6 @@ namespace DeckbuilderLibrary.Data
 {
     public interface IContext
     {
-        void SetCurrentBattle(IBattle battle);
         int GetPlayerHealth();
         IReadOnlyList<IActor> GetEnemies();
         IBattle GetCurrentBattle();
@@ -22,7 +21,7 @@ namespace DeckbuilderLibrary.Data
         int GetDamageAmount(object sender, int baseDamage, IActor target, IActor owner);
         void TryDealDamage(GameEntity source, IActor owner, IActor target, int baseDamage);
         T CreateActor<T>(int health, int armor) where T : Actor, new();
-        IBattle CreateBattle(IDeck deck, PlayerActor player);
+        IBattle CreateBattle(IDeck deck, PlayerActor player, List<Enemy> enemies);
         T CreateIntent<T>(Actor owner) where T : Intent, new();
         T CopyCard<T>(T card) where T : Card;
         T CreateResource<T>(Actor owner, int amount) where T : Resource<T>, IResource, new();


### PR DESCRIPTION
Discard pile moves cards into draw pile when draw pile is empty.
- Added "rules" list to game context for basic game logic that will likely be universal, but will allow us to quickly try out different rulesets.
- Removed SetCurrentBattle from GameContext
closes #19 