### PR TITLE
Make tests run

### DIFF
--- a/Library/DeckbuilderLibrary/DeckbuilderTests/DeckbuilderTests.csproj
+++ b/Library/DeckbuilderLibrary/DeckbuilderTests/DeckbuilderTests.csproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
       <PackageReference Include="NETStandard.Library" Version="2.0.3" />
       <PackageReference Include="NUnit" Version="3.13.2" />
       <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
@@ -15,5 +16,4 @@
       <ProjectReference Include="..\Content\Content.csproj" />
       <ProjectReference Include="..\DeckbuilderLibrary\DeckbuilderLibrary.csproj" />
     </ItemGroup>
-
 </Project>


### PR DESCRIPTION
I have no idea what is wrong with my environment. Rider can't figure out how to run tests.

If a package reference to `Microsoft.NET.Test.Sdk` is added I'm able to run tests using `dotnet test`.

Unlike #30, I'm pretty sure this is only an issue on my end.
